### PR TITLE
Exclude NullReference Exceptions

### DIFF
--- a/rules/aspnet_except.yml
+++ b/rules/aspnet_except.yml
@@ -1,14 +1,16 @@
 ---
 title: ASP Exceptions
 group: Webservers
-description: ASP internal auditing errors and exceptions, often raised during the exploitation of IIS.
+description: ASP internal auditing errors and exceptions.
 authors:
   - sudoREM
+
 
 kind: evtx
 level: high
 status: stable
 timestamp: Event.System.TimeCreated
+
 
 fields:
   - name: Event ID
@@ -25,5 +27,11 @@ fields:
     to: Event.EventData.Data[21]
 
 filter:
-  Event.System.EventID: 1309
-  Event.System.Provider_attributes.Name: "i*ASP.NET*"
+  condition: event_information and not uninteresting
+  event_information:
+    Event.System.EventID: 1309
+    Event.System.Provider_attributes.Name: 'i*ASP.NET*'
+
+  uninteresting:
+    Event.EventData.Data[17]:
+      - "NullReferenceException"

--- a/rules/aspnet_except.yml
+++ b/rules/aspnet_except.yml
@@ -5,12 +5,10 @@ description: ASP internal auditing errors and exceptions.
 authors:
   - sudoREM
 
-
 kind: evtx
 level: high
 status: stable
 timestamp: Event.System.TimeCreated
-
 
 fields:
   - name: Event ID
@@ -30,7 +28,7 @@ filter:
   condition: event_information and not uninteresting
   event_information:
     Event.System.EventID: 1309
-    Event.System.Provider_attributes.Name: 'i*ASP.NET*'
+    Event.System.Provider_attributes.Name: "i*ASP.NET*"
 
   uninteresting:
     Event.EventData.Data[17]:


### PR DESCRIPTION
Excluded NullReferenceExceptions to try and stem the tide of superfluous errors on busy webservers